### PR TITLE
Add escape shortcut key for quick-swiching between editor and renderer

### DIFF
--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -305,6 +305,9 @@ a.header-link:hover {
       overflow: hidden;
     }
   }
+  #block__code-wrapper .CodeMirror-scroll {
+    min-height: 600px;
+  }
 }
 
 /* sidebyside */

--- a/public/js/components/editor__html.js
+++ b/public/js/components/editor__html.js
@@ -85,6 +85,14 @@ var EditorHTML = React.createClass({
         gist.files[this.props.active].content = this.codeMirror.getValue();
         Actions.localGistUpdate(gist);
       });
+      this.codeMirror.on('keydown', function(codeMirror, keyboardEvent) {
+        if (keyboardEvent.keyCode === 27) {  // 27 is keyCode for Escape key
+          if ( (document.body.scrollTop > 0) || (document.documentElement.scrollTop > 0) /* Firefox */ ) 
+            d3.select("div.renderer").classed("popped", function(d){
+              return !d3.select(this).classed('popped');
+            });
+        }
+      });
     });
   },
 


### PR DESCRIPTION
Implemented what we just discussed here: https://github.com/enjalot/building-blocks/issues/28