### PR TITLE
Use OAuth clientId and secret for initial loading of gist on server side

### DIFF
--- a/server.js
+++ b/server.js
@@ -338,6 +338,10 @@ function getGist(gistId, cb) {
   // TODO: add our app's token to avoid rate limiting
   var options = {
     url: "https://api.github.com/gists/" + gistId,
+    qs: {
+      'client_id': nconf.get('github:clientId'),
+      'client_secret': nconf.get('github:secret')
+    },
     headers: {
       'User-Agent': 'Building Bl.ocks'
     }


### PR DESCRIPTION
Use github oauth for making requests from server. Gives us increased number of requests per hour.