### PR TITLE
Added missing package dependency - webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "sass": "^0.5.0",
     "sass-loader": "^1.0.2",
     "superagent": "^1.2.0"
+  },
+  "devDependencies": {
+    "webpack": "^1.12.9"
   }
 }


### PR DESCRIPTION
This way running scripts directly after `npm install` should be possible. Right now there is an error about not installed webpack.